### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
+FROM php:7.2-fpm
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git zip
+
+RUN apt-get install -y sqlite3 libsqlite3-dev
+
+# install the PHP extensions we need
+RUN set -ex; \
+  \
+  if command -v a2enmod; then \
+    a2enmod rewrite; \
+  fi; \
+  \
+  savedAptMark="$(apt-mark showmanual)"; \
+  \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    libjpeg-dev \
+    libpng-dev \
+    libpq-dev \
+  ; \
+  \
+  docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+  docker-php-ext-install -j "$(nproc)" \
+    gd \
+    opcache \
+    pdo_mysql \
+    pdo_pgsql \
+    zip \
+  ; \
+  \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+  apt-mark auto '.*' > /dev/null; \
+  apt-mark manual $savedAptMark; \
+  ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+    | awk '/=>/ { print $3 }' \
+    | sort -u \
+    | xargs -r dpkg-query -S \
+    | cut -d: -f1 \
+    | sort -u \
+    | xargs -rt apt-mark manual; \
+  \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+  rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=60'; \
+    echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.enable_cli=1'; \
+  } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY . /var/www/tome
+WORKDIR /var/www/tome
+RUN composer install  --no-plugins --no-scripts
+EXPOSE 8888
+CMD ["vendor/bin/drush", "runserver", "0.0.0.0:8888"]


### PR DESCRIPTION
Adds a Dockerfile to support Docker base workflows.

To build the container with the name tome run:

```bash
docker build -t tome .
```

To run the container (with the port 8888):

```bash
docker run -v `pwd`/src/drupal/:/var/www/tome -p 8888:8888 tome
```

To do the initialization or run other commands:

```bash
docker run -v `pwd`/src/drupal/:/var/www/tome -p 8888:8888 -it tome vendor/bin/drush tome:init
```