### PR TITLE
Added symlink for libraries

### DIFF
--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -11,3 +11,6 @@ fi
 if [ ! -L web/modules/custom ] && [ ! -e web/modules/custom ]; then
     ln -s ../../modules web/modules/custom
 fi
+if [ ! -L web/libraries ] && [ ! -e web/libraries ]; then
+    ln -s ../libraries web/libraries
+fi


### PR DESCRIPTION
Like custom modules and themes have symlinks for installations, there should a symlinks for libraries directory as well. Faced this while adding a JS lib which broke during deployment.