### PR TITLE
Fix usage instructions for `tome:init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,35 @@ work!
 
 ## Usage
 
-To create a new Tome project, run:
+### Initializing a new project
+
+To create a new Tome project in the `my_site` subdirectory, run:
 
 ```bash
-composer create-project drupal-tome/tome-project my_site --stability dev --no-interaction
-drush tome:init
+mkdir my_site
+cd my_site
+composer create-project drupal-composer/drupal-project:8.x-dev . # <-- the dot at the end means current directory
+composer require drupal-tome/tome-project
+composer update
+```
+
+Create new SQL database `testdb`, with its own separate user `tome` that has all privileges for that database and only for that database, with a password `mypassword`:
+
+```sudo mysql
+MariaDB> create database testdb;
+MariaDB> CREATE USER 'tome'@'localhost' IDENTIFIED BY 'mypassword';
+MariaDB> grant all privileges on testdb.* to 'tome'@'localhost';
+MariaDB> \q
+```
+
+Run the normal `site:init` first to set up the database connection (`tome:init` fails to do that). Use the details (database name, user name, password) from the previous step, and accept defaults for all the other values:
+
+```drush site:init
+```
+
+To finish the installation, run the `tome:init`, accept all defaults:
+
+```drush tome:init
 ```
 
 To re-install Tome, run:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ composer update
 
 Create new SQL database `testdb`, with its own separate user `tome` that has all privileges for that database and only for that database, with a password `mypassword`:
 
-```sudo mysql
+```bash
+sudo mysql
 MariaDB> create database testdb;
 MariaDB> CREATE USER 'tome'@'localhost' IDENTIFIED BY 'mypassword';
 MariaDB> grant all privileges on testdb.* to 'tome'@'localhost';
@@ -37,12 +38,14 @@ MariaDB> \q
 
 Run the normal `site:init` first to set up the database connection (`tome:init` fails to do that). Use the details (database name, user name, password) from the previous step, and accept defaults for all the other values:
 
-```drush site:init
+```bash
+drush site:init
 ```
 
 To finish the installation, run the `tome:init`, accept all defaults:
 
-```drush tome:init
+```bash
+drush tome:init
 ```
 
 To re-install Tome, run:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ work!
 - [Drush](https://github.com/drush-ops/drush-launcher#installation---phar)
 - SQLite and the related PHP extensions
 
-## Usage
-
-### Initializing a new project
+## Initializing a new project
 
 To create a new Tome project in the `my_site` subdirectory, run:
 
@@ -42,11 +40,13 @@ Run the normal `site:init` first to set up the database connection (`tome:init` 
 drush site:init
 ```
 
-To finish the installation, run the `tome:init`, accept all defaults:
+To finish the installation, run `tome:init`, accept all defaults:
 
 ```bash
 drush tome:init
 ```
+
+## Further usage
 
 To re-install Tome, run:
 


### PR DESCRIPTION
`tome:init` requires `site:init` be run first to set up the database connection; update the guide, and add a section on how to create a new database and user, so that one can simply create a new tome project just by following the instructions here, without the need of any previous knowledge.