### PR TITLE
Gitpod setup update

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,3 +18,22 @@ ports:
     onOpen: open-preview
   - port: 8889
     onOpen: ignore
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,6 +22,6 @@ tasks:
     openMode: split-right
 ports:
   - port: 8888
-    onOpen: preview
+    onOpen: open-preview
   - port: 8889
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,28 +1,27 @@
 image: mortenson/tome
 tasks:
   - name: Install tome
-    command: |
+    init: |
       COMPOSER_MEMORY_LIMIT=2048M composer install
+    command: |
       [ -d content ] && drush tome:install -y
       gp sync-done install
   - name: Init and login
-    init: |
+    command: |
       echo "Waiting for install..."
       gp sync-await install
-    command: |
       eval $(gp env -e DRUSH_OPTIONS_URI="0.0.0.0:8888")
       [ ! -d content ] && echo "Looks like you haven't initialized a Tome site yet - make sure to composer require any profiles you want to use (ex: 'composer require drupal-tome/bookish'), then run drush tome:init to get started!"
       [ -d content ] && drush uli
   - name: Runserver
-    init: |
+    command: |
       echo "Waiting for install..."
       gp sync-await install
-    command: |
       [ ! -d content ] && echo "When you're finished running drush tome:init you can use this tab to run your server with 'drush runserver 0.0.0.0:8888'"
       [ -d content ] && drush runserver 0.0.0.0:8888
     openMode: split-right
 ports:
   - port: 8888
-    onOpen: ignore
+    onOpen: preview
   - port: 8889
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,22 +1,15 @@
 image: mortenson/tome
 tasks:
-  - name: Install tome
-    init: |
-      COMPOSER_MEMORY_LIMIT=2048M composer install
-    command: |
-      [ -d content ] && drush tome:install -y
-      gp sync-done install
   - name: Init and login
     command: |
-      echo "Waiting for install..."
-      gp sync-await install
       eval $(gp env -e DRUSH_OPTIONS_URI="0.0.0.0:8888")
       [ ! -d content ] && echo "Looks like you haven't initialized a Tome site yet - make sure to composer require any profiles you want to use (ex: 'composer require drupal-tome/bookish'), then run drush tome:init to get started!"
       [ -d content ] && drush uli
   - name: Runserver
+    init: |
+      COMPOSER_MEMORY_LIMIT=2048M composer install
+      [ -d content ] && drush tome:install -y
     command: |
-      echo "Waiting for install..."
-      gp sync-await install
       [ ! -d content ] && echo "When you're finished running drush tome:init you can use this tab to run your server with 'drush runserver 0.0.0.0:8888'"
       [ -d content ] && drush runserver 0.0.0.0:8888
     openMode: split-right


### PR DESCRIPTION
It's a better user experience, when `composer install` and `drush si` commands run during prebuild (`init` tasks in `.gitpod.yml`)

After prebuild, every workspace a user opens, already have everything installed and ready to work.

This PR simplifies `.gitpod.yml` file and utilizes Gitpod's prebuild functionality.